### PR TITLE
fix resolution bug

### DIFF
--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -38,7 +38,7 @@ Vcc::Vcc( const float correction )
 #define ADMUX_VCCWRT1V1 (_BV(REFS0) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1))
 #endif  
 
-float Vcc::Read_Volts(void)
+uint16_t Vcc::Read_mVolts(void)
 {
   // Read 1.1V reference against AVcc
   // set the reference to Vcc and the measurement to the internal 1.1V reference
@@ -58,12 +58,17 @@ float Vcc::Read_Volts(void)
   // Result is now stored in ADC.
   
   // Calculate Vcc (in V)
-  float vcc = 1.1*1024.0 / ADC;
+  float vcc = 1100 * 1024.0 / ADC;
 
   // Apply compensation
-  vcc *= m_correction;
+  vcc *= m_correction * 1000;
 
   return vcc;
+}
+
+float Vcc::Read_Volts(void)
+{
+  return Read_mVolts / 1000.0;
 }
 
 float Vcc::Read_Perc(const float range_min, const float range_max, const boolean clip)

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -58,7 +58,7 @@ float Vcc::Read_Volts(void)
   // Result is now stored in ADC.
   
   // Calculate Vcc (in V)
-  float vcc = 1.1*1023.0 / ADC;
+  float vcc = 1.1*1024.0 / ADC;
 
   // Apply compensation
   vcc *= m_correction;

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -58,10 +58,10 @@ uint16_t Vcc::Read_mVolts(void)
   // Result is now stored in ADC.
   
   // Calculate Vcc (in V)
-  float vcc = 1100 * 1024.0 / ADC;
+  uint32_t vcc = 1100 * 1024.0 / ADC;
 
   // Apply compensation
-  vcc *= m_correction * 1000;
+  vcc *= m_correction;
 
   return vcc;
 }

--- a/Vcc.cpp
+++ b/Vcc.cpp
@@ -68,7 +68,7 @@ uint16_t Vcc::Read_mVolts(void)
 
 float Vcc::Read_Volts(void)
 {
-  return Read_mVolts / 1000.0;
+  return Read_mVolts() / 1000.0;
 }
 
 float Vcc::Read_Perc(const float range_min, const float range_max, const boolean clip)

--- a/Vcc.h
+++ b/Vcc.h
@@ -45,6 +45,12 @@ class Vcc
      */
     float Read_Volts(void);
 
+		/**
+		 * @brief Read milli volts
+		 * @return Current Vcc level in mV<
+		 */
+		uint16_t Vcc::Read_mVolts(void);
+
     /**
      * Retrieve current Vcc level. The total voltage range shall be passed
      * as low/high bound. For e.g. an alkaline AA battery this range can be set


### PR DESCRIPTION
Hi,

I think it should be 1024 and not 1023 because:
With an 10 Bit ADC you can measure 2^10 = 1024 different states. The first state is 0 and the last state is 1023. From 0 to 1023 it is 1024 steps.
This means, you can measure from 0 V until Referenzvoltage - 1LSB value. For example we have 5 V as reference Voltage:

```
5 V / 1024 = 4.883 mV
0 bits are equal to 0 V
1023 bits are equal to 4.995 V
```

So we can't measure from 0 V to 5 V, because every voltage from 4.995 V and higher will give us 1023 as ADC value.

For this project it means: A 10 bit ADC have 1024 different ADC values and we have to multiply with this and not with the maximum possible ADC value 1023.
There is a difference between the ADC maximum value and the ADC resolution.

Best regards,
Kalle
